### PR TITLE
Copy containerd-shim-runc-v2 binary 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,7 @@
   with_items:
     - containerd
     - containerd-shim
+    - containerd-shim-runc-v2
     - ctr
     - docker
     - dockerd


### PR DESCRIPTION
Copy containerd-shim-runc-v2 to /usr/local/bin/