### PR TITLE
9.0.0+20.10.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v2
         with:
-          path: 'githubixx.docker
+          path: 'githubixx.docker'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+---
+# This workflow requires a GALAXY_API_KEY secret present in the GitHub
+# repository or organization.
+#
+# See: https://github.com/marketplace/actions/publish-ansible-role-to-galaxy
+# See: https://github.com/ansible/galaxy/issues/46
+
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: 'githubixx.docker'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'githubixx.docker
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible.
+        run: pip3 install ansible-core
+
+      - name: Trigger a new import on Galaxy.
+        run: >-
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+molecule/kvm/.vagrant
+.vscode

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 150
+    level: warning
+
+  comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ dockerd_settings:
 ```
 
 - update Docker to `v20.10.22`
+- add support for Ubuntu `22.04` (Jammy Jellyfish)
+- add `iptables`/`nftables` handling
+- add `.gitignore`
 - add `.yamllint`
+- add Molecule `verify` step
+- increase memory for Molecule test instances
 
 ## 8.2.0+20.10.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ dockerd_settings:
 - add `.yamllint`
 - add Molecule `verify` step
 - increase memory for Molecule test instances
+- add Github release action to push new release to Ansible Galaxy
 
 ## 8.2.0+20.10.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,38 @@
-Changelog
----------
+# Changelog
 
-**8.2.0+20.10.17**
+## 9.0.0+20.10.22
+
+- **BREAKING:** `dockerd_settings` now contains the default settings for `dockerd`. Previous versions had optimized settings for Kubernetes. But since Docker is no longer relevant for Kubernetes it makes sense to just use the default settings. Settings before this version:
+
+```yaml
+dockerd_settings:
+  "host": "unix:///run/docker.sock"
+  "log-level": "error"
+  "storage-driver": "overlay2"
+  "iptables": "false"
+  "ip-masq": "false"
+  "bip": ""
+  "mtu": "1472"
+```
+
+- update Docker to `v20.10.22`
+- add `.yamllint`
+
+## 8.2.0+20.10.17
 
 - update Docker to `v20.10.17`
 
-**8.1.0+20.10.12**
+## 8.1.0+20.10.12
 
 - update Docker to `v20.10.12`
 - add missing file `containerd-shim-runc-v2`
 
-**8.0.1+20.10.11**
+## 8.0.1+20.10.11
 
 - update README
 - make `meta/main.yml` valid YAML file
 
-**8.0.0+20.10.11**
+## 8.0.0+20.10.11
 
 - update Docker to `v20.10.11`
 - add support for Debain 10 (Buster) + 11 (Bullseye)
@@ -23,21 +40,21 @@ Changelog
 - `aufs` storage driver is deprecated -> use `overlay2` by default
 - add Molecule tests
 
-**7.0.1+18.09.9**
+## 7.0.1+18.09.9
 
 - added Ubuntu 20.04 (Focal Fossa) as supported platform
 
-**7.0.0+18.09.9**
+## 7.0.0+18.09.9
 
 - Update Docker to `v18.09.9`
 - value for `ListenStream` changed to `/run/docker.sock` (old path is deprecated)
 - change `--storage-driver` to `overlay2` (see [Legacy overlay storage driver](https://docs-stage.docker.com/engine/deprecated/#legacy-overlay-storage-driver))
 
-**no change**
+## no change
 
 - Deleted old tags not supported by Ansible Galaxy:
 
-```
+```bash
 r1.0.0_v17.03.2-ce
 r2.0.0_v17.03.2-ce
 r3.0.0_v17.03.2-ce
@@ -45,47 +62,47 @@ r3.1.0_v17.03.2-ce
 v1.0.0_r1.12.6
 ```
 
-**6.0.0+18.09.6**
+## 6.0.0+18.09.6
 
 - Update Docker to `v18.09.6`
 
-**5.1.0+18.06.1**
+## 5.1.0+18.06.1
 
 - fix link to CHANGELOG
 - update README / provide info about restoring default dockerd settings
 
-**5.0.0+18.06.1**
+## 5.0.0+18.06.1
 
 - restart Docker daemon if docker binaries changes
-- by specifing `--extra-vars="upgrade_docker=true"` to `ansible-playbook` download/unzip of new Docker archive is forced
+- by specifying `--extra-vars="upgrade_docker=true"` to `ansible-playbook` download/unzip of new Docker archive is forced
 
-**4.0.0+18.06.1**
+## 4.0.0+18.06.1
 
-- use correct semantic versioning as described in https://semver.org. Needed for Ansible Galaxy importer as it now insists on using semantic versioning.
+- use correct semantic versioning as described in [semantic versioning](https://semver.org). Needed for Ansible Galaxy importer as it now insists on using semantic versioning.
 - moved changelog entries to separate file
 - make Ansible linter happy
 - use systemd module instead of systemctl command for handlers
 - increase min. Ansible version from 2.2 to 2.4
 - no major changes but decided to start a new major release as versioning scheme changed quite heavily
 
-**r3.1.1_v18.06.1-ce**
+## r3.1.1_v18.06.1-ce
 
 - Update Docker to `v18.06.1-ce`
 
-**r3.1.0_v17.03.2-ce**
+## r3.1.0_v17.03.2-ce
 
 - introduce `docker_ca_certificates_src_dir`, `docker_ca_certificates_dst_dir` and `docker_ca_certificates` variables
 
-**r3.0.0_v17.03.2-ce**
+## r3.0.0_v17.03.2-ce
 
 - works with Ubuntu 18.04
 - update README
 
-**r2.0.0_v17.03.2-ce**
+## r2.0.0_v17.03.2-ce*
 
 - major refactoring
 - introduce flexible parameter settings for dockerd daemon via `dockerd_settings` and `dockerd_settings_user`
 
-**r1.0.0_v17.03.2-ce**
+## r1.0.0_v17.03.2-ce
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ molecule converge
 
 This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `docker` role.
 
+To run a few tests:
+
+```bash
+molecule verify
+```
+
 To clean up run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,8 +32,29 @@ docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
 docker_gid: 666
+
 # Directory to store Docker binaries. Should be in your search PATH!
 docker_bin_dir: "/usr/local/bin"
+
+# For Archlinux the values of this variable can either be "iptables" or
+# "nftables". For all other OSes "iptables" is a requirement as Docker
+# depends on "iptables" command. In case of Archlinux "nftables" also
+# includes "iptables" so both work.
+# 
+# Ubuntu 18.04, 20.04 and Debian 10 only provides "iptables".
+#
+# Ubuntu 22.04 and Debian 11 allows to install "iptables" and "nftables"
+# in parallel.
+#
+# So for Archlinux if either "iptables" or "iptables-nft" package is
+# already installed this role won't change anything. For all other OSes
+# "iptables" package is a requirement. So even if "nftables" package is
+# already installed this role will install "iptables" package.
+#
+# Possible values:
+# - iptables # Possible for all supported OSes
+# - nftables # Only for Archlinux
+docker_firewall_flavor: "iptables"
 
 # Settings for "dockerd" daemon. Will be provided as parameter to "dockerd" in
 # systemd service file for Docker. These variables and it's values can be
@@ -46,7 +67,6 @@ dockerd_settings:
   "storage-driver": "overlay2"
   "iptables": "true"
   "ip-masq": "true"
-  "bip": "172.17.0.0/16"
   "mtu": "1500"
 
 # To override settings defined in `dockerd_settings` this variable can be
@@ -59,18 +79,18 @@ dockerd_settings:
 
 # The directory from where to copy the Docker CA certificates. By default this
 # will expand to user's LOCAL $HOME (the user that run's "ansible-playbook ..."
-# plus "/docker-ca-certificates". That means if the user's $HOME directory is e.g.
-# "/home/da_user" then "docker_ca_certificates_src_dir" will have a value of
-# "/home/da_user/docker-ca-certificates".
+# plus "/docker-ca-certificates". That means if the user's $HOME directory is
+# e.g. "/home/da_user" then "docker_ca_certificates_src_dir" will have a value
+# of "/home/da_user/docker-ca-certificates".
 docker_ca_certificates_src_dir: "{{ '~/docker-ca-certificates' | expanduser }}"
 
-# The directory where the program "update-ca-certificates" searches for CA certificate
-# files (besides other locations).
+# The directory where the program "update-ca-certificates" searches for CA
+# certificate files (besides other locations).
 docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 ```
 
 Variables with no defaults:
-
+ 
 ```yaml
 # If you've a Docker registry with a self signed certificate you can copy the
 # certificate authority (CA) file to the remote host to the CA certificate store.
@@ -93,7 +113,6 @@ dockerd_settings_user:
   "storage-driver": "aufs"
   "iptables": "false"
   "ip-masq": "false"
-  "bip": "172.18.0.0/16"
   "mtu": "1400"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 ansible-role-docker
 ===================
 
-Installs Docker from official Docker binaries archive (no PPA or apt repository). For managing Docker daemon systemd is used. Should work with basically every Linux OS using `systemd`. This Ansible playbook is used in [Kubernetes the not so hard way with Ansible - Control plane](https://www.tauceti.blog/posts/kubernetes-the-not-so-hard-way-with-ansible-control-plane/) and [Kubernetes the not so hard way with Ansible - Worker](https://www.tauceti.blog/posts/kubernetes-the-not-so-hard-way-with-ansible-worker-2020/).
+Installs Docker from official Docker binaries archive (no PPA or apt repository). For managing Docker daemon systemd is used. Should work with basically every Linux OS using `systemd`.
 
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `8.0.0+20.10.11` means this is release `8.0.0` of this role and it's meant to be used with Docker version `20.10.11`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `9.0.0+20.10.22` means this is release `9.0.0` of this role and it's meant to be used with Docker version `20.10.22`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
 
 Requirements
 ------------
 
 A recent kernel should be used (something like >= 4.4.x). It makes sense to use a recent kernel for Docker in general. I recommend to use >= 4.8.x if possible. Ubuntu 18.04 and up have already a descent kernel by default. Verify that you have `overlay2` filesystem available if you want to use it instead of e.g. `aufs` which is recommended in production (should be the case for kernel >= 4.4.x). Meanwhile `aufs` is deprecated anyways. But you can change the storage driver in the `dockerd_settings_user` (see below for more information) if you like.
-
-**NOTE**: The default variables of the role variables are configured to work with Kubernetes (and `Flannel` overlay network or `Cilium`). If you want to use this role without Kubernetes you may want to adjust a few settings (especially `iptables`, `ip-masq`, `bip` and `mtu` `dockerd_settings`). See comment for `dockerd_settings` for more information. I disabled most parts of `Docker` networking as it' not needed for `Kubernetes`.
 
 Changelog
 ---------
@@ -23,12 +21,13 @@ see [Changelog](https://github.com/githubixx/ansible-role-docker/blob/master/CHA
 Role Variables
 --------------
 
-```
+```yaml
+---
 # Directory to store downloaded Docker archive and unarchived binary files.
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "20.10.17"
+docker_version: "20.10.22"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
@@ -36,29 +35,27 @@ docker_gid: 666
 # Directory to store Docker binaries. Should be in your search PATH!
 docker_bin_dir: "/usr/local/bin"
 
-# Settings for "dockerd" daemon. Will be provided as paramter to "dockerd" in
-# systemd service file for Docker. This settings are used to work out of the
-# box with Kubernetes, Flannel network overlay or Cilium. If you don't need this
-# and just want to use "default" Docker networking see below (`dockerd_settings_user`
-# variable):
+# Settings for "dockerd" daemon. Will be provided as parameter to "dockerd" in
+# systemd service file for Docker. These variables and it's values can be
+# overridden with `dockerd_settings_user` variable. Also additional variables
+# can be added of course. For possible values see:
+# https://docs.docker.com/engine/reference/commandline/dockerd/#daemon
 dockerd_settings:
   "host": "unix:///run/docker.sock"
-  "log-level": "error"
+  "log-level": "info"
   "storage-driver": "overlay2"
-  "iptables": "false"
-  "ip-masq": "false"
-  "bip": ""
-  "mtu": "1472"
+  "iptables": "true"
+  "ip-masq": "true"
+  "bip": "172.17.0.0/16"
+  "mtu": "1500"
 
-# If you need the default Docker settings define this variable in "group_vars/all.yml" e.g.:
+# To override settings defined in `dockerd_settings` this variable can be
+# used. Of course additional variables can be added too. The example below
+# would add the "--debug=true" switch to `dockerd` e.g. For possible values
+# see:
+# https://docs.docker.com/engine/reference/commandline/dockerd/#daemon
 # dockerd_settings_user:
-# "host": "unix:///run/docker.sock"
-# "log-level": "info"
-# "storage-driver": "aufs"
-# "iptables": "true"
-# "ip-masq": "true"
-# "bip": "172.17.0.0/16"
-# "mtu": "1500"
+#   "debug": "true"
 
 # The directory from where to copy the Docker CA certificates. By default this
 # will expand to user's LOCAL $HOME (the user that run's "ansible-playbook ..."
@@ -74,7 +71,7 @@ docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 
 Variables with no defaults:
 
-```
+```yaml
 # If you've a Docker registry with a self signed certificate you can copy the
 # certificate authority (CA) file to the remote host to the CA certificate store.
 # This way Docker will trust the SSL certificate of your Docker registry.
@@ -87,20 +84,20 @@ docker_ca_certificates:
   - ca-docker.crt
 ```
 
-These settings for `dockerd` daemon defined in `dockerd_settings` can be overridden by defining a variable called `dockerd_settings_user`. You can also add additional settings by using this variable. E.g. if you add the following variable and it's settings to `group_vars/all.yml` (or where ever it fit's best for you) `dockerd` will run with the default settings and overrides the default settings of this role (see above):
+The settings for `dockerd` daemon defined in `dockerd_settings` can be overridden by defining a variable called `dockerd_settings_user`. You can also add additional settings by using this variable. E.g. if you add the following variables and their values to `group_vars/all.yml` (or where ever it fit's best for you) `dockerd` the default settings will be overridden (see above):
 
-```
+```yaml
 dockerd_settings_user:
-  "host": "unix:///run/docker.sock"
-  "log-level": "info"
+  "host": "unix:///var/run/docker.sock"
+  "log-level": "error"
   "storage-driver": "aufs"
-  "iptables": "true"
-  "ip-masq": "true"
-  "bip": "172.17.0.0/16"
-  "mtu": "1500"
+  "iptables": "false"
+  "ip-masq": "false"
+  "bip": "172.18.0.0/16"
+  "mtu": "1400"
 ```
 
-Of course you can add more settings. Just add ;-)
+Of course you can add more settings.
 
 Upgrading Docker
 ---------------
@@ -110,7 +107,7 @@ If you want upgrade Docker update `docker_version` variable accordingly. Afterwa
 Example Playbook
 ----------------
 
-```
+```yaml
 - hosts: docker_hosts
   roles:
     - githubixx.docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ docker_bin_dir: "/usr/local/bin"
 # "nftables". For all other OSes "iptables" is a requirement as Docker
 # depends on "iptables" command. In case of Archlinux "nftables" also
 # includes "iptables" so both work.
-# 
+#
 # Ubuntu 18.04, 20.04 and Debian 10 only provides "iptables".
 #
 # Ubuntu 22.04 and Debian 11 allows to install "iptables" and "nftables"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "20.10.17"
+docker_version: "20.10.22"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
@@ -11,37 +11,35 @@ docker_gid: 666
 # Directory to store Docker binaries. Should be in your search PATH!
 docker_bin_dir: "/usr/local/bin"
 
-# Settings for "dockerd" daemon. Will be provided as paramter to "dockerd" in
-# systemd service file for Docker. This settings are used to work out of the
-# box with Kubernetes, Flannel network overlay or Cilium. If you don't need this
-# and just want to use "default" Docker networking see below (`dockerd_settings_user`
-# variable):
+# Settings for "dockerd" daemon. Will be provided as parameter to "dockerd" in
+# systemd service file for Docker. These variables and it's values can be
+# overridden with `dockerd_settings_user` variable. Also additional variables
+# can be added of course. For possible values see:
+# https://docs.docker.com/engine/reference/commandline/dockerd/#daemon
 dockerd_settings:
   "host": "unix:///run/docker.sock"
-  "log-level": "error"
+  "log-level": "info"
   "storage-driver": "overlay2"
-  "iptables": "false"
-  "ip-masq": "false"
-  "bip": ""
-  "mtu": "1472"
+  "iptables": "true"
+  "ip-masq": "true"
+  "bip": "172.17.0.0/16"
+  "mtu": "1500"
 
-# If you need the default Docker settings define this variable in "group_vars/all.yml" e.g.:
+# To override settings defined in `dockerd_settings` this variable can be
+# used. Of course additional variables can be added too. The example below
+# would add the "--debug=true" switch to `dockerd` e.g. For possible values
+# see:
+# https://docs.docker.com/engine/reference/commandline/dockerd/#daemon
 # dockerd_settings_user:
-# "host": "unix:///run/docker.sock"
-# "log-level": "info"
-# "storage-driver": "overlay2"
-# "iptables": "true"
-# "ip-masq": "true"
-# "bip": "172.17.0.0/16"
-# "mtu": "1500"
+#   "debug": "true"
 
 # The directory from where to copy the Docker CA certificates. By default this
 # will expand to user's LOCAL $HOME (the user that run's "ansible-playbook ..."
-# plus "/docker-ca-certificates". That means if the user's $HOME directory is e.g.
-# "/home/da_user" then "docker_ca_certificates_src_dir" will have a value of
-# "/home/da_user/docker-ca-certificates".
+# plus "/docker-ca-certificates". That means if the user's $HOME directory is
+# e.g. "/home/da_user" then "docker_ca_certificates_src_dir" will have a value
+# of "/home/da_user/docker-ca-certificates".
 docker_ca_certificates_src_dir: "{{ '~/docker-ca-certificates' | expanduser }}"
 
-# The directory where the program "update-ca-certificates" searches for CA certificate
-# files (besides other locations).
+# The directory where the program "update-ca-certificates" searches for CA
+# certificate files (besides other locations).
 docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,29 @@ docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
 docker_gid: 666
+
 # Directory to store Docker binaries. Should be in your search PATH!
 docker_bin_dir: "/usr/local/bin"
+
+# For Archlinux the values of this variable can either be "iptables" or
+# "nftables". For all other OSes "iptables" is a requirement as Docker
+# depends on "iptables" command. In case of Archlinux "nftables" also
+# includes "iptables" so both work.
+# 
+# Ubuntu 18.04, 20.04 and Debian 10 only provides "iptables".
+#
+# Ubuntu 22.04 and Debian 11 allows to install "iptables" and "nftables"
+# in parallel.
+#
+# So for Archlinux if either "iptables" or "iptables-nft" package is
+# already installed this role won't change anything. For all other OSes
+# "iptables" package is a requirement. So even if "nftables" package is
+# already installed this role will install "iptables" package.
+#
+# Possible values:
+# - iptables # Possible for all supported OSes
+# - nftables # Only for Archlinux
+docker_firewall_flavor: "iptables"
 
 # Settings for "dockerd" daemon. Will be provided as parameter to "dockerd" in
 # systemd service file for Docker. These variables and it's values can be
@@ -22,7 +43,6 @@ dockerd_settings:
   "storage-driver": "overlay2"
   "iptables": "true"
   "ip-masq": "true"
-  "bip": "172.17.0.0/16"
   "mtu": "1500"
 
 # To override settings defined in `dockerd_settings` this variable can be

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
       versions:
         - "focal"
         - "bionic"
+        - "jammy"
     - name: Debian
       versions:
         - "buster"
@@ -19,3 +20,5 @@ galaxy_info:
   galaxy_tags:
     - docker
     - container
+    - role
+    - ansible

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021 Robert Wimmer
+# Copyright (C) 2021-2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - hosts: all

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021 Robert Wimmer
+# Copyright (C) 2021-2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:
@@ -10,46 +10,62 @@ driver:
   provider:
     name: libvirt
     type: libvirt
-    options:
-      memory: 384
-      cpus: 2
 
 platforms:
-  - name: test-docker-ubuntu2004
-    box: generic/ubuntu2004
+  - name: test-docker-ubuntu2204
+    box: generic/ubuntu2204
+    memory: 1024
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.10
-  - name: test-docker-ubuntu1804
-    box: generic/ubuntu1804
+  - name: test-docker-ubuntu2004
+    box: generic/ubuntu2004
+    memory: 512
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.20
-  - name: test-docker-debian10
-    box: generic/debian10
+  - name: test-docker-ubuntu1804
+    box: generic/ubuntu1804
+    memory: 512
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.30
-  - name: test-docker-debian11
-    box: generic/debian11
+  - name: test-docker-debian10
+    box: generic/debian10
+    memory: 512
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.40
-  - name: test-docker-archlinux
-    box: archlinux/archlinux
+  - name: test-docker-debian11
+    box: generic/debian11
+    memory: 512
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.50
+  - name: test-docker-archlinux
+    box: archlinux/archlinux
+    memory: 512
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.60
 
 provisioner:
   name: ansible
@@ -59,6 +75,10 @@ provisioner:
   log: true
   lint:
     name: ansible-lint
+  inventory:
+    host_vars:
+      test-docker-archlinux:
+        docker_firewall_flavor: "nftables"
 
 scenario:
   name: default

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ driver:
     name: libvirt
     type: libvirt
     options:
-      memory: 256
+      memory: 384
       cpus: 2
 
 platforms:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,25 +1,39 @@
 ---
-- name: Prepare
+- name: Prepare Ubuntu 22.04
+  hosts: test-docker-ubuntu2204
+  gather_facts: false
+  tasks:
+    - name: Install python3-requests package
+      ansible.builtin.package:
+        name: "python3-requests"
+        state: present
+
+- name: Prepare Archlinux
   hosts: test-docker-archlinux
   gather_facts: false
   tasks:
     - name: Init pacman
-      raw: |
+      ansible.builtin.raw: |
         pacman-key --init
         pacman-key --populate archlinux
       become: true
 
     - name: Updating pacman cache
-      raw: pacman -Sy
+      ansible.builtin.raw: pacman -Sy
       become: true
 
     - name: Install python for Ansible
-      raw: test -e /usr/bin/python || (pacman --noconfirm python)
+      ansible.builtin.raw: test -e /usr/bin/python || (pacman --noconfirm python)
       become: true
 
     - name: Upgrade the whole system
-      raw: pacman --noconfirm -Su
+      ansible.builtin.raw: pacman --noconfirm -Su
       become: true
 
+    - name: Install python3-requests package
+      ansible.builtin.package:
+        name: "python-requests"
+        state: present
+
     - name: Reboot for kernel updates
-      reboot:
+      ansible.builtin.reboot:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,31 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Verify setup
+  hosts: all
+  vars:
+    hosts_count: "test"
+  tasks:
+    - name: Pull image
+      community.docker.docker_image:
+        name: xperimental/goecho
+        tag: v1.8
+        source: pull
+        pull:
+          platform: amd64
+
+    - name: Start container
+      community.docker.docker_container:
+        name: goecho
+        image: xperimental/goecho:v1.8
+        state: started
+        ports:
+          - "8080:8080"
+
+    - name: Check goecho output
+      ansible.builtin.uri:
+        url: http://localhost:8080
+        return_content: yes
+      register: goecho
+      failed_when: "'User-Agent' not in goecho.content"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -24,6 +24,6 @@
     - name: Check goecho output
       ansible.builtin.uri:
         url: http://localhost:8080
-        return_content: yes
+        return_content: true
       register: goecho
       failed_when: "'User-Agent' not in goecho.content"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,8 +4,6 @@
 
 - name: Verify setup
   hosts: all
-  vars:
-    hosts_count: "test"
   tasks:
     - name: Pull image
       community.docker.docker_image:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,56 @@
 ---
-- name: Include variables
+- name: Load common variables
   ansible.builtin.include_vars:
     file: "main.yml"
   tags:
     - docker
+
+- name: Load required variables based on the OS type
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}.yml"
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}.yml"
+    - "{{ ansible_distribution | lower }}.yml"
+    - "{{ ansible_os_family | lower }}.yml"
+  tags:
+    - always
+
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Register if iptables/nftables is installed
+  when:
+    - "docker__ip_nft_tables_package.value in ansible_facts.packages"
+  ansible.builtin.set_fact:
+    docker__ip_nft_tables_installed: true
+  loop: "{{ docker_ip_nft_tables_packages | dict2items }}"
+  loop_control:
+    loop_var: docker__ip_nft_tables_package
+
+- name: Print if iptables/nftables is installed
+  when:
+    - docker__ip_nft_tables_installed is defined
+    - docker__ip_nft_tables_installed
+  ansible.builtin.debug:
+    msg: "Either iptables or nftables is installed"
+
+- name: Install required iptables packages
+  when:
+    - docker__ip_nft_tables_installed is not defined
+    - docker_firewall_flavor == "iptables"
+  ansible.builtin.package:
+    name: "{{ docker_ip_nft_tables_packages.iptables }}"
+    state: present
+
+- name: Install required nftables packages
+  when:
+    - docker__ip_nft_tables_installed is not defined
+    - docker_firewall_flavor == "nftables"
+  ansible.builtin.package:
+    name: "{{ docker_ip_nft_tables_packages.nftables }}"
+    state: present
 
 - name: Copy certificates for Docker registries (if provided)
   ansible.builtin.copy:

--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -1,0 +1,4 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"
+  nftables: "iptables-nft"

--- a/vars/debian-10.yml
+++ b/vars/debian-10.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"

--- a/vars/ubuntu-18.yml
+++ b/vars/ubuntu-18.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"

--- a/vars/ubuntu-22.yml
+++ b/vars/ubuntu-22.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"


### PR DESCRIPTION
- **BREAKING:** `dockerd_settings` now contains the default settings for `dockerd`. Previous versions had optimized settings for Kubernetes. But since Docker is no longer relevant for Kubernetes it makes sense to just use the default settings. Settings before this version:

```yaml
dockerd_settings:
  "host": "unix:///run/docker.sock"
  "log-level": "error"
  "storage-driver": "overlay2"
  "iptables": "false"
  "ip-masq": "false"
  "bip": ""
  "mtu": "1472"
```

- update Docker to `v20.10.22`
- add support for Ubuntu `22.04` (Jammy Jellyfish)
- add `iptables`/`nftables` handling
- add `.gitignore`
- add `.yamllint`
- add Molecule `verify` step
- increase memory for Molecule test instances
- add Github release action to push new release to Ansible Galaxy