### PR TITLE
11.2.0+26.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 11.2.0+26.1.0
 
 - update Docker to `v26.1.0`
+- update Docker compose to `v2.27.0`
+- Molecule: use `alvistack` instead of `generic` Vagrant boxes for Ubuntu
 
 ## 11.1.0+25.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 11.2.0+26.1.0
+
+- update Docker to `v26.1.0`
+
 ## 11.1.0+25.0.0
 
 - add support for installing `docker-compose`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 #docker_compose_type: "standalone"
 
 # "docker-compose" version
-docker_compose_version: "2.24.2"
+docker_compose_version: "2.27.0"
 
 # The directory where to "docker-compose" binary will be installed
 docker_compose_bin_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Installs Docker from official Docker binaries archive (no PPA or apt repository)
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `11.0.0+25.0.0` means this is release `11.0.0` of this role and it's meant to be used with Docker version `25.0.0`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `11.2.0+26.1.0` means this is release `11.2.0` of this role and it's meant to be used with Docker version `26.1.0`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
 
 ## Changelog
 
@@ -17,7 +17,7 @@ see [Changelog](https://github.com/githubixx/ansible-role-docker/blob/master/CHA
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "25.0.0"
+docker_version: "26.1.0"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "25.0.0"
+docker_version: "26.1.0"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,7 +72,7 @@ docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 #docker_compose_type: "standalone"
 
 # "docker-compose" version
-docker_compose_version: "2.24.2"
+docker_compose_version: "2.27.0"
 
 # The directory where to "docker-compose" binary will be installed
 docker_compose_bin_directory: "/usr/local/bin"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -71,7 +71,7 @@ provisioner:
       test-docker-archlinux:
         docker_firewall_flavor: "nftables"
       test-docker-ubuntu2204:
-        docker_compose_type: "standalone" 
+        docker_compose_type: "standalone"
 
 scenario:
   name: default

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-docker-ubuntu2204
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 1536
     cpus: 2
     interfaces:
@@ -22,7 +22,7 @@ platforms:
         type: static
         ip: 172.16.10.10
   - name: test-docker-ubuntu2004
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-20.04
     memory: 1536
     cpus: 2
     interfaces:


### PR DESCRIPTION
- update Docker to `v26.1.0`
- update Docker compose to `v2.27.0`
- Molecule: use `alvistack` instead of `generic` Vagrant boxes for Ubuntu