### PR TITLE
13.0.0+28.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 molecule/kvm/.vagrant
 .vscode
+.ansible

--- a/.yamllint
+++ b/.yamllint
@@ -7,3 +7,11 @@ rules:
     level: warning
 
   comments-indentation: disable
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 13.0.0+28.3.2
+
+- **UPDATE**
+  - update Docker to `v28.3.2`
+  - update Docker Compose to `v2.38.2`
+
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+  - Install `archlinux-keyring` for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
+  - Remove `vars/ubuntu-20.yml` as Ubuntu 20.04 support was dropped
+  - Removed 'Upgrade the whole system' task
+
+- **OTHER CHANGES**
+  - update `.yamllint`
+  - fix `ansible-lint` issues
+  - add `.ansible` directory to `.gitignore`
+
 ## 12.0.0+27.0.3
 
 - update Docker to `v27.0.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ dockerd_settings:
 ## 8.0.0+20.10.11
 
 - update Docker to `v20.10.11`
-- add support for Debain 10 (Buster) + 11 (Bullseye)
+- add support for Debian 10 (Buster) + 11 (Bullseye)
 - add support for Archlinux
 - `aufs` storage driver is deprecated -> use `overlay2` by default
 - add Molecule tests

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ see [Changelog](https://github.com/githubixx/ansible-role-docker/blob/master/CHA
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "27.0.3"
+docker_version: "28.3.2"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
@@ -30,10 +30,8 @@ docker_bin_dir: "/usr/local/bin"
 # "nftables". For all other OSes "iptables" is a requirement as Docker
 # depends on "iptables" command. In case of Archlinux "nftables" also
 # includes "iptables" so both work.
-# 
-# Ubuntu 20.04 and Debian 10 only provides "iptables".
 #
-# Ubuntu 22.04, 22.04, Debian 11 and 12 allows to install "iptables" and "nftables"
+# Ubuntu 22.04, 24.04 and Debian 11 allows to install "iptables" and "nftables"
 # in parallel.
 #
 # So for Archlinux if either "iptables" or "iptables-nft" package is
@@ -83,10 +81,10 @@ docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 # plugin (without "-").
 # When commented no "docker-compose" will be installed and all "docker_compose_*"
 # variables are ignored.
-#docker_compose_type: "standalone"
+# docker_compose_type: "standalone"
 
 # "docker-compose" version
-docker_compose_version: "2.28.1"
+docker_compose_version: "2.38.2"
 
 # The directory where to "docker-compose" binary will be installed
 docker_compose_bin_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Installs Docker from official Docker binaries archive (no PPA or apt repository)
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `12.0.0+27.0.3` means this is release `12.0.0` of this role and it's meant to be used with Docker version `27.0.3`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `13.0.0+28.3.2` means this is release `13.0.0` of this role and it's meant to be used with Docker version `28.3.2`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
 
 ## Changelog
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 # plugin (without "-").
 # When commented no "docker-compose" will be installed and all "docker_compose_*"
 # variables are ignored.
-#docker_compose_type: "standalone"
+# docker_compose_type: "standalone"
 
 # "docker-compose" version
 docker_compose_version: "2.38.2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,8 +17,6 @@ docker_bin_dir: "/usr/local/bin"
 # depends on "iptables" command. In case of Archlinux "nftables" also
 # includes "iptables" so both work.
 #
-# Ubuntu 20.04 and Debian 10 only provides "iptables".
-#
 # Ubuntu 22.04, 24.04 and Debian 11 allows to install "iptables" and "nftables"
 # in parallel.
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "27.0.3"
+docker_version: "28.3.2"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,7 @@ docker_ca_certificates_dst_dir: "/usr/local/share/ca-certificates"
 #docker_compose_type: "standalone"
 
 # "docker-compose" version
-docker_compose_version: "2.28.1"
+docker_compose_version: "2.38.2"
 
 # The directory where to "docker-compose" binary will be installed
 docker_compose_bin_directory: "/usr/local/bin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "bionic"
         - "jammy"
         - "noble"
     - name: Debian

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,11 +2,12 @@
 # Copyright (C) 2021-2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: all
+- name: Setup Docker
+  hosts: all
   remote_user: vagrant
   become: true
   gather_facts: true
   tasks:
     - name: Include Docker role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.docker

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -57,7 +57,7 @@ platforms:
         type: static
         ip: 172.16.10.50
   - name: test-docker-archlinux
-    box: archlinux/archlinux
+    box: generic/arch
     memory: 1536
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,17 +23,6 @@ platforms:
         network_name: private_network
         type: static
         ip: 172.16.10.10
-  - name: test-docker-ubuntu2004
-    box: alvistack/ubuntu-20.04
-    memory: 1536
-    cpus: 2
-    groups:
-      - ubuntu
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.20
   - name: test-docker-ubuntu2404
     box: alvistack/ubuntu-24.04
     memory: 1536

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -21,28 +21,22 @@
       ansible.builtin.raw: |
         pacman-key --init
         pacman-key --populate archlinux
-      become: true
+      changed_when: false
+      failed_when: false
 
     - name: Updating pacman cache
-      raw: pacman -Sy
-      become: true
+      ansible.builtin.raw: |
+        pacman -Sy
+      changed_when: false
 
     - name: Install Python
       ansible.builtin.raw: |
-        pacman -S --noconfirm python
+        pacman -S --noconfirm python openssl
       args:
         executable: /bin/bash
       changed_when: false
-      become: true
-
-    - name: Upgrade the whole system
-      ansible.builtin.raw: pacman --noconfirm -Su
-      become: true
 
     - name: Install python3-requests package
       ansible.builtin.package:
         name: "python-requests"
         state: present
-
-    - name: Reboot for kernel updates
-      ansible.builtin.reboot:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -29,9 +29,9 @@
         pacman -Sy
       changed_when: false
 
-    - name: Install Python
+    - name: Install support packages
       ansible.builtin.raw: |
-        pacman -S --noconfirm python openssl
+        pacman -S --noconfirm python openssl archlinux-keyring
       args:
         executable: /bin/bash
       changed_when: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -42,4 +42,4 @@
     - name: Ensure docker-compose --version output
       ansible.builtin.assert:
         that:
-          - "docker_compose_version_output in docker__docker_compose_version.stdout"      
+          - "docker_compose_version_output in docker__docker_compose_version.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
   ansible.builtin.copy:
     src: "{{ docker_ca_certificates_src_dir }}/{{ item }}"
     dest: "{{ docker_ca_certificates_dst_dir }}/{{ item }}"
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
   with_items:
@@ -94,7 +94,7 @@
   ansible.builtin.file:
     path: "{{ docker_download_dir }}"
     state: directory
-    mode: 0750
+    mode: "0750"
   tags:
     - docker
 
@@ -109,7 +109,7 @@
   ansible.builtin.get_url:
     url: "https://download.docker.com/linux/static/stable/x86_64/docker-{{ docker_version }}.tgz"
     dest: "{{ docker_download_dir }}/docker-{{ docker_version }}.tgz"
-    mode: 0640
+    mode: "0640"
   when: not docker_bin_stat.stat.exists or (upgrade_docker is defined and upgrade_docker == "true")
   tags:
     - docker
@@ -127,7 +127,7 @@
   ansible.builtin.copy:
     src: "{{ docker_download_dir }}/docker/{{ binary }}"
     dest: "{{ docker_bin_dir }}/{{ binary }}"
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
     remote_src: true
@@ -151,7 +151,7 @@
     dest: /etc/systemd/system/docker.socket
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - Reload systemd
     - Restart docker
@@ -164,7 +164,7 @@
     dest: /etc/systemd/system/docker.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - Reload systemd
     - Restart docker

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -1,3 +1,0 @@
----
-docker_ip_nft_tables_packages:
-  iptables: "iptables"


### PR DESCRIPTION
- **UPDATE**
  - update Docker to `v28.3.2`
  - update Docker Compose to `v2.38.2`

- **MOLECULE**
  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
  - Install `openssl` package for Archlinux
  - Install `archlinux-keyring` for Archlinux
  - Removed Ubuntu 20.04 because reached end of life
  - Remove `vars/ubuntu-20.yml` as Ubuntu 20.04 support was dropped
  - Removed 'Upgrade the whole system' task

- **OTHER CHANGES**
  - update `.yamllint`
  - fix `ansible-lint` issues
  - add `.ansible` directory to `.gitignore`
