### PR TITLE
fix: use ansible var instead hardcode arch type

### DIFF
--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -1,9 +1,9 @@
 ---
 - name: Downloading docker-compose binary
   ansible.builtin.get_url:
-    url: "https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}/docker-compose-linux-x86_64"
+    url: "https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}/docker-compose-{{ ansible_system | lower }}-{{ ansible_architecture }}"
     dest: "{{ docker_compose_bin_directory }}/docker-compose"
     mode: "{{ docker_compose_bin_file_perm }}"
     owner: "{{ docker_compose_bin_owner }}"
     group: "{{ docker_compose_bin_group }}"
-    checksum: "sha256:https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}//docker-compose-linux-x86_64.sha256"
+    checksum: "sha256:https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}//docker-compose-{{ ansible_system | lower }}-{{ ansible_architecture }}.sha256"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,7 +107,7 @@
 
 - name: Downloading official Docker binaries archive
   ansible.builtin.get_url:
-    url: "https://download.docker.com/linux/static/stable/x86_64/docker-{{ docker_version }}.tgz"
+    url: "https://download.docker.com/linux/static/stable/{{ ansible_architecture }}/docker-{{ docker_version }}.tgz"
     dest: "{{ docker_download_dir }}/docker-{{ docker_version }}.tgz"
     mode: "0640"
   when: not docker_bin_stat.stat.exists or (upgrade_docker is defined and upgrade_docker == "true")

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,0 +1,3 @@
+---
+docker_ip_nft_tables_packages:
+  iptables: "iptables"


### PR DESCRIPTION
## Description

Thanks for your hard works for this role, this changes fixing 2 issues, which not running seamlessly in some cases.

1. Changes help roles to support dynamic for:
   - system types: darwin, linux, etc
   - architecture types: x86_64, aarch64, arm64, etc
2. Help to pick default variables if specific version is not supported yet

The changes temporarily used in https://github.com/devetek/belajar-ansible/blob/main/ansible/requirements.yml#L68 before this PR merge!