### PR TITLE
14.0.0+29.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,9 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/g') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }}
+          -vvv
+          --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 |
+          sed 's/ansible-role-//' | sed 's/-/_/g')
+          $(echo ${{ github.repository }} | cut -d/ -f1)
+          $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 150
+    max: 200
     level: warning
 
   comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **BREAKING**
   - remove `Debian 11` support
+  - changing `docker_version` or `docker_compose_version` now automatically updates the installed binaries on the next run; `upgrade_docker=true` is no longer required for version-driven upgrades and now acts as a force-reinstall flag
 
 - **UPDATE**
   - update Docker to `v29.4.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 14.0.0+29.4.3
+
+- **BREAKING**
+  - remove `Debian 11` support
+
+- **UPDATE**
+  - update Docker to `v29.4.3`
+  - add `Ubuntu 26.04` support
+  - add `Debian 13` support
+  - update `docker-compose` binary only when needed
+  - ensure needed kernel modules for Docker are loaded
+  - ensure python3-apt installed on Archlinux + Debian based OSes
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
+  - update tests
+
+- **OTHER CHANGES**
+  - update `.yamllint`
+  - truthy value should be "true" / fix file permissions
+  - fix line length in `.github/workflows/release.yml`
+
 ## 13.1.0+28.3.2
 
 - **UPDATE**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Installs Docker from official Docker binaries archive (no PPA or apt repository)
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `13.0.0+28.3.2` means this is release `13.0.0` of this role and it's meant to be used with Docker version `28.3.2`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag like `13.0.0+29.4.3` means this is release `13.0.0` of this role and it's meant to be used with Docker version `29.4.3`. If the role itself changes `X.Y.Z` before `+` will increase. If the Docker version changes `XX.YY.ZZ` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Docker release.
 
 ## Changelog
 
@@ -13,6 +13,28 @@ I tag every release and try to stay with [semantic versioning](http://semver.org
 See full [CHANGELOG](https://github.com/githubixx/ansible-role-docker/blob/master/CHANGELOG.md)
 
 **Recent changes:**
+
+### 14.0.0+29.4.3
+
+- **BREAKING**
+  - remove `Debian 11` support
+
+- **UPDATE**
+  - update Docker to `v29.4.3`
+  - add `Ubuntu 26.04` support
+  - add `Debian 13` support
+  - update `docker-compose` binary only when needed
+  - ensure needed kernel modules for Docker are loaded
+  - ensure python3-apt installed on Archlinux + Debian based OSes
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
+  - update tests
+
+- **OTHER CHANGES**
+  - update `.yamllint`
+  - truthy value should be "true" / fix file permissions
+  - fix line length in `.github/workflows/release.yml`
 
 ### 13.1.0+28.3.2
 
@@ -57,7 +79,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-docker/blob/maste
 roles:
   - name: githubixx.docker
     src: https://github.com/githubixx/ansible-role-docker.git
-    version: 13.1.0+28.3.2
+    version: 14.0.0+29.4.3
 ```
 
 ## Role Variables
@@ -67,7 +89,7 @@ roles:
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "28.3.2"
+docker_version: "29.4.3"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
@@ -75,6 +97,13 @@ docker_gid: 666
 
 # Directory to store Docker binaries. Should be in your search PATH!
 docker_bin_dir: "/usr/local/bin"
+
+# Kernel modules required for Docker bridge networking on minimal hosts.
+docker_kernel_modules:
+  - overlay
+  - br_netfilter
+  - bridge
+  - veth
 
 # For Archlinux the values of this variable can either be "iptables" or
 # "nftables". For all other OSes "iptables" is a requirement as Docker
@@ -192,7 +221,7 @@ If you want upgrade Docker update `docker_version` variable accordingly. Afterwa
 
 ## Testing
 
-This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-docker/tree/master/molecule/default).
+This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The [Molecule test configuration](https://github.com/githubixx/ansible-role-docker/tree/master/molecule/default) is available in this repository.
 
 Afterwards molecule can be executed:
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ Of course you can add more settings.
 
 ## Upgrading Docker
 
-If you want upgrade Docker update `docker_version` variable accordingly. Afterwards if you run `ansible-playbook` and supply the argument `--extra-vars="upgrade_docker=true"` the playbook will download the specified Docker version and installs the binaries. This will cause systemd to restart `docker.service`. To avoid restarting all Docker daemons on all of your hosts at once consider using `--limit` parameter or reduce parallel Ansible tasks with `--forks`.
+If you want to upgrade Docker update `docker_version` accordingly and run `ansible-playbook`. The role compares the installed Docker version with `docker_version` and downloads or reinstalls the binaries when the versions differ. This causes systemd to restart `docker.service`.
+
+You can still use `--extra-vars="upgrade_docker=true"` to force a reinstall even if the installed version already matches `docker_version`. The same flag also forces a reinstall of the standalone `docker-compose` binary when enabled.
+
+To avoid restarting all Docker daemons on all of your hosts at once consider using `--limit` or reduce parallel Ansible tasks with `--forks`.
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 docker_download_dir: "/opt/tmp"
 
 # Docker version to download and use.
-docker_version: "28.3.2"
+docker_version: "29.4.3"
 docker_user: "docker"
 docker_group: "docker"
 docker_uid: 666
@@ -11,6 +11,13 @@ docker_gid: 666
 
 # Directory to store Docker binaries. Should be in your search PATH!
 docker_bin_dir: "/usr/local/bin"
+
+# Kernel modules required for Docker bridge networking on minimal hosts.
+docker_kernel_modules:
+  - overlay
+  - br_netfilter
+  - bridge
+  - veth
 
 # For Archlinux the values of this variable can either be "iptables" or
 # "nftables". For all other OSes "iptables" is a requirement as Docker

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,10 +12,12 @@ galaxy_info:
       versions:
         - "jammy"
         - "noble"
+        - "resolute"
     - name: Debian
       versions:
         - "bullseye"
         - "bookworm"
+        - "trixie"
   galaxy_tags:
     - docker
     - container

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,14 @@
   become: true
   gather_facts: true
   tasks:
+    - name: Remove python3-apt on Debian family hosts
+      when:
+        - ansible_facts['os_family'] == "Debian"
+      ansible.builtin.raw: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get remove -y python3-apt || true
+      changed_when: false
+
     - name: Include Docker role
       ansible.builtin.include_role:
         name: githubixx.docker

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -33,6 +33,17 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
+        ip: 172.16.10.20
+  - name: test-docker-ubuntu2604
+    box: githubixx/ubuntu-26.04
+    memory: 1536
+    cpus: 2
+    groups:
+      - ubuntu
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
         ip: 172.16.10.30
   - name: test-docker-debian12
     box: githubixx/debian-12

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-docker-ubuntu2204
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-22.04
     memory: 1536
     cpus: 2
     groups:
@@ -24,7 +24,7 @@ platforms:
         type: static
         ip: 172.16.10.10
   - name: test-docker-ubuntu2404
-    box: alvistack/ubuntu-24.04
+    box: githubixx/ubuntu-24.04
     memory: 1536
     cpus: 2
     groups:
@@ -35,7 +35,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-docker-debian12
-    box: generic/debian12
+    box: githubixx/debian-12
     memory: 1536
     cpus: 2
     groups:
@@ -45,8 +45,8 @@ platforms:
         network_name: private_network
         type: static
         ip: 172.16.10.40
-  - name: test-docker-debian11
-    box: generic/debian11
+  - name: test-docker-debian13
+    box: githubixx/debian-13
     memory: 1536
     cpus: 2
     groups:
@@ -57,7 +57,7 @@ platforms:
         type: static
         ip: 172.16.10.50
   - name: test-docker-archlinux
-    box: generic/arch
+    box: githubixx/archlinux
     memory: 1536
     cpus: 2
     groups:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -46,5 +46,6 @@
         path: /etc/resolv.conf
         line: "nameserver 127.0.0.53"
         state: present
-        backup: yes
-        create: yes
+        mode: "0644"
+        backup: true
+        create: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,28 +5,50 @@
 - name: Verify setup
   hosts: all
   tasks:
+    - name: Remove legacy verify containers
+      community.docker.docker_container:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - nginx
+        - docker-bridge-diagnostic
+        - docker-verify-http
+
     - name: Pull image
       community.docker.docker_image:
-        name: xperimental/goecho
-        tag: v1.8
+        name: busybox
+        tag: stable
         source: pull
-        pull:
-          platform: amd64
 
     - name: Start container
       community.docker.docker_container:
-        name: goecho
-        image: xperimental/goecho:v1.8
+        name: docker-verify-http
+        image: busybox:stable
         state: started
-        ports:
+        recreate: true
+        published_ports:
           - "8080:8080"
+        command:
+          - sh
+          - -c
+          - "mkdir -p /www && printf 'docker-role-ok\n' >/www/index.html && exec httpd -f -p 8080 -h /www"
 
-    - name: Check goecho output
+    - name: Wait for test HTTP port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 8080
+        timeout: 30
+
+    - name: Check HTTP output
       ansible.builtin.uri:
         url: http://localhost:8080
         return_content: true
-      register: goecho
-      failed_when: "'User-Agent' not in goecho.content"
+      register: docker__http
+      retries: 5
+      delay: 2
+      until:
+        - docker__http.status == 200
+        - "'docker-role-ok' in docker__http.content"
 
 - name: Verify docker-compose installed
   hosts: test-docker-ubuntu2204

--- a/tasks/docker-compose.yml
+++ b/tasks/docker-compose.yml
@@ -1,9 +1,39 @@
 ---
+- name: Register docker-compose binary is installed
+  ansible.builtin.stat:
+    path: "{{ docker_compose_bin_directory }}/docker-compose"
+  register: docker__docker_compose_bin_stat
+
+- name: Register installed docker-compose version
+  when: docker__docker_compose_bin_stat.stat.exists
+  ansible.builtin.command:
+    cmd: "{{ docker_compose_bin_directory }}/docker-compose version --short"
+  register: docker__docker_compose_version_installed
+  changed_when: false
+
+- name: Register if docker-compose binary needs installation
+  ansible.builtin.set_fact:
+    docker__install_docker_compose: >-
+      {{
+        (not docker__docker_compose_bin_stat.stat.exists)
+        or (upgrade_docker | default(false) | bool)
+        or (
+          (
+            docker__docker_compose_version_installed.stdout
+            | default('')
+            | trim
+          ) != docker_compose_version
+        )
+      }}
+
 - name: Downloading docker-compose binary
   ansible.builtin.get_url:
-    url: "https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}/docker-compose-{{ ansible_system | lower }}-{{ ansible_architecture }}"
+    url: >-
+      https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}/docker-compose-{{ ansible_facts['system'] | lower }}-{{ ansible_facts['architecture'] }}
     dest: "{{ docker_compose_bin_directory }}/docker-compose"
     mode: "{{ docker_compose_bin_file_perm }}"
     owner: "{{ docker_compose_bin_owner }}"
     group: "{{ docker_compose_bin_group }}"
-    checksum: "sha256:https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}//docker-compose-{{ ansible_system | lower }}-{{ ansible_architecture }}.sha256"
+    checksum: >-
+      sha256:https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}//docker-compose-{{ ansible_facts['system'] | lower }}-{{ ansible_facts['architecture'] }}.sha256
+  when: docker__install_docker_compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,13 +8,27 @@
 - name: Load required variables based on the OS type
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_release'] }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}.yml"
+    - "{{ ansible_facts['os_family'] | lower }}.yml"
   tags:
     - always
+
+- name: Bootstrap python3-apt on Debian family hosts
+  when:
+    - ansible_facts['os_family'] == "Debian"
+  ansible.builtin.raw: |
+    if python3 -c 'import apt' >/dev/null 2>&1; then
+      echo "python3-apt already present"
+    else
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y python3-apt
+    fi
+  register: docker__python3_apt_bootstrap
+  changed_when: "'python3-apt already present' not in docker__python3_apt_bootstrap.stdout"
 
 - name: Gather the package facts
   ansible.builtin.package_facts:
@@ -52,6 +66,29 @@
     name: "{{ docker_ip_nft_tables_packages.nftables }}"
     state: present
 
+- name: Persist Docker kernel modules
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/docker.conf
+    content: |
+      {% for docker__kernel_module in docker_kernel_modules %}
+      {{ docker__kernel_module }}
+      {% endfor %}
+    owner: root
+    group: root
+    mode: "0644"
+  tags:
+    - docker
+
+- name: Load Docker kernel modules
+  ansible.builtin.command:
+    cmd: "modprobe {{ docker__kernel_module }}"
+  loop: "{{ docker_kernel_modules }}"
+  loop_control:
+    loop_var: docker__kernel_module
+  changed_when: false
+  tags:
+    - docker
+
 - name: Copy certificates for Docker registries (if provided)
   ansible.builtin.copy:
     src: "{{ docker_ca_certificates_src_dir }}/{{ item }}"
@@ -68,6 +105,8 @@
 
 - name: Update CA certificates
   ansible.builtin.command: "update-ca-certificates"
+  register: docker__update_ca_certificates
+  changed_when: "'0 added, 0 removed; done.' not in docker__update_ca_certificates.stdout"
   when: docker_ca_certificates is defined
   tags:
     - docker
@@ -105,12 +144,40 @@
   tags:
     - docker
 
+- name: Register installed Docker CLI version
+  when: docker_bin_stat.stat.exists
+  ansible.builtin.command:
+    cmd: "{{ docker_bin_dir }}/docker --version"
+  register: docker__docker_cli_version
+  changed_when: false
+  tags:
+    - docker
+
+- name: Register if Docker binaries need installation
+  ansible.builtin.set_fact:
+    docker__install_binaries: >-
+      {{
+        (not docker_bin_stat.stat.exists)
+        or (upgrade_docker | default(false) | bool)
+        or (
+          (
+            docker__docker_cli_version.stdout
+            | default('')
+            | regex_findall('[0-9]+\.[0-9]+\.[0-9]+')
+            | first
+            | default('')
+          ) != docker_version
+        )
+      }}
+  tags:
+    - docker
+
 - name: Downloading official Docker binaries archive
   ansible.builtin.get_url:
-    url: "https://download.docker.com/linux/static/stable/{{ ansible_architecture }}/docker-{{ docker_version }}.tgz"
+    url: "https://download.docker.com/linux/static/stable/{{ ansible_facts['architecture'] }}/docker-{{ docker_version }}.tgz"
     dest: "{{ docker_download_dir }}/docker-{{ docker_version }}.tgz"
     mode: "0640"
-  when: not docker_bin_stat.stat.exists or (upgrade_docker is defined and upgrade_docker == "true")
+  when: docker__install_binaries
   tags:
     - docker
 
@@ -119,7 +186,7 @@
     src: "{{ docker_download_dir }}/docker-{{ docker_version }}.tgz"
     dest: "{{ docker_download_dir }}"
     remote_src: true
-  when: not docker_bin_stat.stat.exists or (upgrade_docker is defined and upgrade_docker == "true")
+  when: docker__install_binaries
   tags:
     - docker
 
@@ -136,6 +203,7 @@
   loop: "{{ docker_binaries }}"
   loop_control:
     loop_var: "binary"
+  when: docker__install_binaries
   tags:
     - docker
 


### PR DESCRIPTION
- **BREAKING**
  - remove `Debian 11` support
  - changing `docker_version` or `docker_compose_version` now automatically updates the installed binaries on the next run; `upgrade_docker=true` is no longer required for version-driven upgrades and now acts as a force-reinstall flag

- **UPDATE**
  - update Docker to `v29.4.3`
  - add `Ubuntu 26.04` support
  - add `Debian 13` support
  - update `docker-compose` binary only when needed
  - ensure needed kernel modules for Docker are loaded
  - ensure python3-apt installed on Archlinux + Debian based OSes

- **MOLECULE**
  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
  - update tests

- **OTHER CHANGES**
  - update `.yamllint`
  - truthy value should be "true" / fix file permissions
  - fix line length in `.github/workflows/release.yml`